### PR TITLE
Test/Production Environment Split

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN mkdir -p /var/log/freeradius/
 RUN touch /var/log/freeradius/radius.log
 
 
+
 EXPOSE 1812/udp
 EXPOSE 1813/udp
 WORKDIR /root

--- a/files/run.sh
+++ b/files/run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+ENV1="PRODUCTION"
+ENV2="TEST"
+
 sed -i -e "s/EDUROAM_FLR1/$EDUROAM_FLR1/g" -e "s/EDUROAM_FLR2/$EDUROAM_FLR2/g" -e "s/FLR_EDUROAM_SECRET/$FLR_EDUROAM_SECRET/g" \
 	/etc/raddb/clients.conf
 
@@ -18,5 +21,10 @@ sed -i -e "s/YOUR_REALM/$YOUR_REALM/g" /etc/raddb/sites-enabled/eduroam
 sed -i -e "s/YOUR_REALM/$YOUR_REALM/g" -e "s/TEST_PASSWORD/$TEST_PASSWORD/g" /etc/raddb/mods-config/files/authorize
 
 
-
-/usr/local/raddb/sbin/radiusd -xx -l /var/log/freeradius/radius.log -f
+if [ "$ENVIRONMENT" = "$ENV1" ]; then
+	/usr/local/raddb/sbin/radiusd -f 
+elif [ "$ENVIRONMENT" = "$ENV2" ]; then
+ 	/usr/local/raddb/sbin/radiusd -X -l /var/log/freeradius/radius.log -f
+else
+ 	echo ERROR
+fi

--- a/restart_eduroamFreeRADIUS.sh
+++ b/restart_eduroamFreeRADIUS.sh
@@ -5,10 +5,12 @@ EDUROAM_FLR2=192.168.100.110
 FLR_EDUROAM_SECRET=supertest
 YOUR_REALM=docker.sg
 TEST_PASSWORD=docker123
+ENVIRONMENT=TEST #TEST or PRODUCTION
 
+ 
 docker stop freeradius-eduroam; docker rm freeradius-eduroam
 docker run -d --name freeradius-eduroam -v /etc/localtime:/etc/localtime:ro -p 1812:1812/udp -p 1813:1813/udp \
   -e EDUROAM_FLR1=$EDUROAM_FLR1 -e EDUROAM_FLR2=$EDUROAM_FLR2 -e FLR_EDUROAM_SECRET=$FLR_EDUROAM_SECRET \
-  -e YOUR_REALM=$YOUR_REALM -e  TEST_PASSWORD=$TEST_PASSWORD \
+  -e YOUR_REALM=$YOUR_REALM -e  TEST_PASSWORD=$TEST_PASSWORD -e ENVIRONMENT=$ENVIRONMENT \
   spgreen/freeradius-eduroam
 


### PR DESCRIPTION
Allows the user to select either the TEST or PRODUCTION Environment by configuring the setting in restart_eduroamFreeRADIUS.sh

TEST -  has debugging features enabled such as in-depth authentication logs in   /var/log/freeradius/radius.log . The log file growth rate is significant after numerous authentication request. Other logs found here: /usr/local/raddb/var/log/radius/radacct/<FLR IP ADDRESS/

PRODUCTION - limited logs. Logs found in /usr/local/raddb/var/log/radius/radacct/<FLR IP ADDRESS/
