### PR TITLE
minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN wget ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.10.tar.bz
 		./configure --prefix=/usr/local/raddb/ --sysconfdir=/etc && \
      		make && \
      		make install && \
+                cd && \
+                rm -rf /opt/freeradius-server-3.0.10 && \
     mkdir -p /var/log/freeradius/ && \
         touch /var/log/freeradius/radius.log 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN     sed -i 's/allow_vulnerable_openssl.*/allow_vulnerable_openssl = CVE-2014
 EXPOSE 1812/udp 1813/udp
 WORKDIR /root
 
-CMD /root/run.sh 
+CMD ["/root/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:precise
 
-RUN apt-get update && apt-get upgrade 
+RUN apt-get update && apt-get -y upgrade 
 
 #Installs necessary dependencies for compiling FreeRADIUS and other useful tools such as vim and tcpdump
 RUN apt-get -y install \

--- a/files/environment/etc/raddb/mods-enabled/linelog
+++ b/files/environment/etc/raddb/mods-enabled/linelog
@@ -68,7 +68,7 @@ linelog {
 	#
 	#  Followed by a series of log messages.
 	# Access-Request = "Requested access: %{User-Name}"
-        Access-Request = "\"%S\",\"%{reply:Packet-Type}\",\"%{Operator-Name}\",\"%{Packet-Src-IP-Address}\",\"%{NAS-IP-Address}\",\"%{Client-Shortname}\",\"%{User-Name}\""
+        Access-Request = "\"%S\",\"%{reply:Packet-Type}\",\"%{reply:Chargeable-User-Identity}\",\"%{Operator-Name}\",\"%{Packet-Src-IP-Address}\",\"%{NAS-IP-Address}\",\"%{Client-Shortname}\",\"%{User-Name}\""
 	Access-Reject = "Rejected access: %{User-Name}"
 	Access-Challenge = "Sent challenge: %{User-Name}"
 

--- a/files/environment/root/run.sh
+++ b/files/environment/root/run.sh
@@ -27,6 +27,7 @@ sed -i -e "s/YOUR_REALM/$YOUR_REALM/g" -e "s/TEST_PASSWORD/$TEST_PASSWORD/g" /et
 if [ "$NO_OF_FLR_SERVERS" = 1 ]; then
 	sed -i -e '304,310 s/^/#/' /etc/raddb/clients.conf
 	sed -i -e '13,18 s/^/#/' /etc/raddb/proxy.conf
+        sed -i -e "s/\(home_server[\t ]*= FLR2\)/#&1/" /etc/raddb/proxy.conf
 fi
 
 #Configures the environment (TEST or PRODUCTION)

--- a/files/environment/root/run.sh
+++ b/files/environment/root/run.sh
@@ -29,11 +29,11 @@ if [ "$NO_OF_FLR_SERVERS" = 1 ]; then
 	sed -i -e '13,18 s/^/#/' /etc/radddb/proxy.conf
 fi
 
-#Configures the environment (TEST or PRODUCTION) 
+#Configures the environment (TEST or PRODUCTION)
 if [ "$ENVIRONMENT" = "$ENV1" ]; then
-	/usr/local/raddb/sbin/radiusd -f 
+	exec /usr/local/raddb/sbin/radiusd -f
 elif [ "$ENVIRONMENT" = "$ENV2" ]; then
- 	/usr/local/raddb/sbin/radiusd -X -l /var/log/freeradius/radius.log -f
+	exec /usr/local/raddb/sbin/radiusd -X -l /var/log/freeradius/radius.log -f
 else
- 	echo ERROR
+	echo ERROR
 fi

--- a/files/environment/root/run.sh
+++ b/files/environment/root/run.sh
@@ -26,7 +26,7 @@ sed -i -e "s/YOUR_REALM/$YOUR_REALM/g" -e "s/TEST_PASSWORD/$TEST_PASSWORD/g" /et
 #Configures the number of FLR Servers between 1 to 2. If 1 is selected in the restart script, the 2nd FLR Variables will be commented out
 if [ "$NO_OF_FLR_SERVERS" = 1 ]; then
 	sed -i -e '304,310 s/^/#/' /etc/raddb/clients.conf
-	sed -i -e '13,18 s/^/#/' /etc/radddb/proxy.conf
+	sed -i -e '13,18 s/^/#/' /etc/raddb/proxy.conf
 fi
 
 #Configures the environment (TEST or PRODUCTION)


### PR DESCRIPTION
Hi Simon,

Minor fixes to your container:
- run radiusd as process 1 (remove dangling shell processes) to properly receive SIGTERM when container is stopping
- fix a filename typo in a sed call from run.sh (changes to proxy.conf commenting out FLR2 were not happening)
- after the above fix, I found I also had to remove FLR2 from the pool, otherwise radiusd would not start

More by email.

Cheers,
Vlad 
