### PR TITLE
Update rad_eap_test - add OperatorName and CUI

### DIFF
--- a/files/environment/bin/rad_eap_test
+++ b/files/environment/bin/rad_eap_test
@@ -28,7 +28,7 @@ OUT2=$CONF.out2
 #echo $CONF $OUT
 
 # path to eapol test
-EAPOL_PROG=/bin/eapol_test
+EAPOL_PROG=eapol_test
 
 # default verbosity
 VERBOSE=0
@@ -66,7 +66,7 @@ if [ ! -x "$EAPOL_PROG" ]; then # exact path?
 fi
 
 #TEMP=`getopt -o H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:vc -- "$@"`
-TEMP=`getopt -o H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:2:vcN -- "$@"`
+TEMP=`getopt -o H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:2:vcNO:I:C -- "$@"`
 
 if [ -z $1 ] ; then echo "# wrapper script around eapol_test from wpa_supplicant project 
 # script generates configuration for eapol_test and runs it 
@@ -94,6 +94,9 @@ Parameters :
 -a <ca_cert_file> - certificate of CA
 -2 <phase2 method> - Phase2 type (PAP,CHAP,MSCHAPV2)
 -N - Identify and do not delete temporary files
+-O <domain.edu.cctld> - Operator-Name value in domain name format
+-I <ip address> - explicitly specify NAS-IP-Address
+-C - request Chargeable-User-Identity
 " >&2 ; exit 1 ; fi
 
 eval set -- "$TEMP"
@@ -123,6 +126,9 @@ while true ; do
 		-l) KEY_PASS=$2; shift 2;;
     -2) PHASE2=$2; shift 2;;
     -N) CLEANUP=0; shift ;;
+    -O) OPERATOR_NAME=$2; shift 2;;
+    -I) NAS_IP_ADDRESS=$2; shift 2;;
+    -C) REQUEST_CUI="YES"; shift ;;
     --) break ;;
     *) echo "Unknown option"; shift ;;  # I mean that getopt throws out unrecongized options, therefore this line cannot be running
   esac
@@ -203,6 +209,19 @@ if [ -z $PHASE2 ]; then
 	PHASE2="MSCHAPV2"
 fi
 
+if [ -n "$OPERATOR_NAME" ] ; then
+	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N126:s:$OPERATOR_NAME"
+fi
+
+if [ -n "$NAS_IP_ADDRESS" ] ; then
+        NAS_IP_ADDRESS_HEX=$( printf '%02x%02x%02x%02x' $( echo "$NAS_IP_ADDRESS" | tr '.' ' ' ) )
+	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N4:x:$NAS_IP_ADDRESS_HEX"
+fi
+
+if [ -n "$REQUEST_CUI" ] ; then
+	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N89:x:00"
+fi
+
 # generation of configuration
 echo "network={" > $CONF
 echo "  ssid=\"$SSID\"" >> $CONF
@@ -269,16 +288,16 @@ trap garbage INT
 
 BEGIN=`date +%s`
 
-#echo "$EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $STATUS_DIR"
+#echo "$EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $EXTRA_EAPOL_ARGS $STATUS_DIR"
 
 # try authenticate
 if [ $VERBOSE -eq 0 ]; then
-  $EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $STATUS_DIR | awk '/^SUCCESS$/ {exit '$RET_SUCC';} /^CTRL-EVENT-EAP-FAILURE EAP authentication failed$/ {exit '$RET_EAP_FAILED';} /^EAPOL test timed out$/ {exit '$RET_RADIUS_NOT_AVAIL';} /^CTRL-EVENT-EAP-SUCCESS EAP authentication completed successfully$/ {exit '$RET_SUCC';} /^EAP: Received EAP-Failure$/ {exit '$RET_EAP_FAILED';} /Access-Reject/ {exit '$RET_EAP_FAILED';} ' > $OUT
+  $EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $EXTRA_EAPOL_ARGS $STATUS_DIR | awk '/^SUCCESS$/ {exit '$RET_SUCC';} /^CTRL-EVENT-EAP-FAILURE EAP authentication failed$/ {exit '$RET_EAP_FAILED';} /^EAPOL test timed out$/ {exit '$RET_RADIUS_NOT_AVAIL';} /^CTRL-EVENT-EAP-SUCCESS EAP authentication completed successfully$/ {exit '$RET_SUCC';} /^EAP: Received EAP-Failure$/ {exit '$RET_EAP_FAILED';} /Access-Reject/ {exit '$RET_EAP_FAILED';} ' > $OUT
 else
   if [ $VERBOSE -eq 1 ]; then
-    $EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $STATUS_DIR |  awk '/RADIUS message/ {print} /Attribute/ {print} /Value/ {print} /^SUCCESS$/ {exit '$RET_SUCC';} /^CTRL-EVENT-EAP-FAILURE EAP authentication failed$/ {exit '$RET_EAP_FAILED';} /^EAPOL test timed out$/ {exit '$RET_RADIUS_NOT_AVAIL';} /^CTRL-EVENT-EAP-SUCCESS EAP authentication completed successfully$/ {exit '$RET_SUCC';} /^EAP: Received EAP-Failure$/ {exit '$RET_EAP_FAILED';}  /Access-Reject/ {exit '$RET_EAP_FAILED';} '  > $OUT2
+    $EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $EXTRA_EAPOL_ARGS $STATUS_DIR |  awk '/RADIUS message/ {print} /Attribute/ {print} /Value/ {print} /^SUCCESS$/ {exit '$RET_SUCC';} /^CTRL-EVENT-EAP-FAILURE EAP authentication failed$/ {exit '$RET_EAP_FAILED';} /^EAPOL test timed out$/ {exit '$RET_RADIUS_NOT_AVAIL';} /^CTRL-EVENT-EAP-SUCCESS EAP authentication completed successfully$/ {exit '$RET_SUCC';} /^EAP: Received EAP-Failure$/ {exit '$RET_EAP_FAILED';}  /Access-Reject/ {exit '$RET_EAP_FAILED';} '  > $OUT2
   else
-    $EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $STATUS_DIR |  awk '/RADIUS message/ {print} /Attribute/ {print} /Value/ {print} /polish/ {print} /^SUCCESS$/ {exit '$RET_SUCC';} /^CTRL-EVENT-EAP-FAILURE EAP authentication failed$/ {exit '$RET_EAP_FAILED';} /^EAPOL test timed out$/ {exit '$RET_RADIUS_NOT_AVAIL';}  /^CTRL-EVENT-EAP-SUCCESS EAP authentication completed successfully$/ {exit '$RET_SUCC';} /^EAP: Received EAP-Failure$/ {exit '$RET_EAP_FAILED';} /Access-Reject/ {exit '$RET_EAP_FAILED';} ' > $OUT
+    $EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $EXTRA_EAPOL_ARGS $STATUS_DIR |  awk '/RADIUS message/ {print} /Attribute/ {print} /Value/ {print} /polish/ {print} /^SUCCESS$/ {exit '$RET_SUCC';} /^CTRL-EVENT-EAP-FAILURE EAP authentication failed$/ {exit '$RET_EAP_FAILED';} /^EAPOL test timed out$/ {exit '$RET_RADIUS_NOT_AVAIL';}  /^CTRL-EVENT-EAP-SUCCESS EAP authentication completed successfully$/ {exit '$RET_SUCC';} /^EAP: Received EAP-Failure$/ {exit '$RET_EAP_FAILED';} /Access-Reject/ {exit '$RET_EAP_FAILED';} ' > $OUT
   fi
 fi
 


### PR DESCRIPTION
Import https://github.com/REANNZ/etcbd/blob/master/environment/icinga/rad_eap_test
with new options:

-O <domain.edu.cctld> - Operator-Name value in domain name format
-I <ip address> - explicitly specify NAS-IP-Address
-C - request Chargeable-User-Identity
