### PR TITLE
test.sh: pass YOUR_REALM as Operator_Name

### DIFF
--- a/files/environment/root/test.sh
+++ b/files/environment/root/test.sh
@@ -8,13 +8,15 @@ FLR_SELECT=$3
 sed -e "s/USERNAME/$USERNAME/" -e "s/PASSWORD/$PASSWORD/" test.conf.template > test.conf
 
 if [ "$FLR_SELECT" = 1 ]; then
-
-    eapol_test -c test.conf -a EDUROAM_FLR1 -p 1812 -s FLR_EDUROAM_SECRET
-
+    RADIUS_SERVER=EDUROAM_FLR1
 elif [ "$FLR_SELECT" = 2 ]; then
+    RADIUS_SERVER=EDUROAM_FLR2
+else
+    RADIUS_SERVER=
+fi
 
-    eapol_test -c test.conf -a EDUROAM_FLR2 -p 1812 -s FLR_EDUROAM_SECRET
-
+if [ -n "$RADIUS_SERVER" ] ; then
+    eapol_test -c test.conf -a $RADIUS_SERVER -p 1812 -s FLR_EDUROAM_SECRET
 else
     echo
     echo " Re-run the command using the following format:"

--- a/files/environment/root/test.sh
+++ b/files/environment/root/test.sh
@@ -7,6 +7,12 @@ FLR_SELECT=$3
 
 sed -e "s/USERNAME/$USERNAME/" -e "s/PASSWORD/$PASSWORD/" test.conf.template > test.conf
 
+if [ -n "$YOUR_REALM" ] ; then
+    EAPOL_EXTRA="-N126:s:$YOUR_REALM"
+else
+    EAPOL_EXTRA=""
+fi
+
 if [ "$FLR_SELECT" = 1 ]; then
     RADIUS_SERVER=EDUROAM_FLR1
 elif [ "$FLR_SELECT" = 2 ]; then
@@ -16,7 +22,7 @@ else
 fi
 
 if [ -n "$RADIUS_SERVER" ] ; then
-    eapol_test -c test.conf -a $RADIUS_SERVER -p 1812 -s FLR_EDUROAM_SECRET
+    eapol_test -c test.conf -a $RADIUS_SERVER -p 1812 -s FLR_EDUROAM_SECRET $EAPOL_EXTRA
 else
     echo
     echo " Re-run the command using the following format:"


### PR DESCRIPTION
Hi @spgreen 

As discussed - this makes test.sh pass YOUR_REALM as Operator_Name.

I did a bit of refactoring to have only one line invoking eapol_test to avoid duplication.

Cheers,
Vlad