### PR TITLE
test.sh: prefix OpName with NamespaceID 1 (REALM)

### DIFF
--- a/files/environment/root/test.sh
+++ b/files/environment/root/test.sh
@@ -8,7 +8,8 @@ FLR_SELECT=$3
 sed -e "s/USERNAME/$USERNAME/" -e "s/PASSWORD/$PASSWORD/" test.conf.template > test.conf
 
 if [ -n "$YOUR_REALM" ] ; then
-    EAPOL_EXTRA="-N126:s:$YOUR_REALM"
+    # prefix the Operator_Name with NamespaceID value "1" (REALM) as per RFC5580
+    EAPOL_EXTRA="-N126:s:1$YOUR_REALM"
 else
     EAPOL_EXTRA=""
 fi


### PR DESCRIPTION
Follow up to #13 - thanks to @alanbuxey for spotting the missing NamespaceID

test.sh: prefix OpName with NamespaceID 1 (REALM) as per RFC 5580

https://tools.ietf.org/html/rfc5580#section-4.1